### PR TITLE
Fix virtual keyboard display on mobile device

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -7,6 +7,7 @@
         <link rel="shortcut icon" href="favicon.ico" type="image/x-icon" />
     </head>
     <body>
+        <input type="text" id="hidden-input"/>
         <div id="content"></div>
         
         <script src="/socket.io/socket.io.js"></script>

--- a/web/init.js
+++ b/web/init.js
@@ -267,6 +267,10 @@
         return output;
     }
 
+    content.click(function (e) {
+	$("#hidden-input").focus();
+    });
+
     $(window.document).keydown(function (e) {
         var part1, part2;
 

--- a/web/main.css
+++ b/web/main.css
@@ -11,3 +11,8 @@ body {
     background-color: #FFFFFF;
 	color: #290029;
 }
+
+#hidden-input {
+    position: absolute;
+    top: -100px;
+}


### PR DESCRIPTION
## Changes
1. Added an input field to `index.html`
2. Changed `main.css` to position the input out of user's view
3. Added event handler to focus the input (causing virtual keybord to show) when `content.click` event is fired
## Test Environment
- Device: iPad 2 
- OS: iOS 7
- Browser: Safari and Chrome 
