### PR TITLE
exec function for client-side javascript

### DIFF
--- a/examples/embeded-iframe/d1.html
+++ b/examples/embeded-iframe/d1.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+
+<html>
+<!-- For cross port iframes http://stackoverflow.com/questions/1481251/what-does-document-domain-document-domain-do -->
+<script>
+document.domain = document.domain;
+</script>
+<body>
+<div class="content">hello world</div>
+<iframe src="http://localhost:8000/terminal/" height="800" width="800"></iframe>
+</body>
+
+</html>

--- a/examples/embeded-iframe/d2.html
+++ b/examples/embeded-iframe/d2.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+
+<html>
+
+<body>
+<div id="content">hola earth</div>
+
+<script>
+var get = function() {
+  return document.getElementById("content").innerHTML
+}
+window.parent.get = get
+</script>
+
+</body>
+
+</html>

--- a/web/index.html
+++ b/web/index.html
@@ -1,6 +1,10 @@
 <!DOCTYPE html>
 <html>
     <head>
+    <!-- REQUIRED for cross port iframes http://stackoverflow.com/questions/1481251/what-does-document-domain-document-domain-do -->
+    <script>
+      document.domain = document.domain;
+    </script>
         <title>Web Terminal</title>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
         <meta name="viewport" content="user-scalable=no, initial-scale=1.0, maximum-scale=1.0" />

--- a/web/init.js
+++ b/web/init.js
@@ -61,6 +61,28 @@
         cursor,
         srvOS;
 
+    // The exec function
+    var exec = function(cmd, callback) {
+      var stdout = ''
+      var socket = io.connect()
+      socket.once("exit", function (data) {
+        callback(stdout)
+      });
+
+      socket.on("console", function (data) {
+        stdout += data
+      });
+
+      currentLine = cmd
+      var e = jQuery.Event("keypress")
+      e.which = 13
+      e.keyCode = 13
+      $(window.document).trigger(e)
+    }
+    window.exec = exec
+
+    if (window.hasOwnProperty('parent')) window.parent.exec = exec
+
     function parseVT100(i, data, closures) {
         var code    = "",
             output  = "",


### PR DESCRIPTION
AKA Expose an `exec` function so other web apps can use web-terminal to run commands

Hi there - I'm building an Web App that exposes a form based GUI that runs commands via web-terminal. Much like `exec` in other languages, here's a client side implementation of `exec` that utilizes `web-terminal`. 

Example:
```javascript
exec('ls -l', function(stdout) { console.log(stdout) })
```

To allow isolating of the web-terminal program and a web app (web app might not want jquery mobile library), I also added the ability to run this `exec` function from the a parent to a `web-terminal` iframe. There are some restrictions to this such as needing to be on the same domain, but you can be at different ports which works for my purposes where there is an app running at domain `localhost` on port 80 while `web-terminal` is running on `localhost:8080`.  

I also added an example. It could be cleaned up if there is a desire to accept this pull request.
![screen shot 2015-04-13 at 9 26 47 pm](https://cloud.githubusercontent.com/assets/156575/7128759/f03d3d5c-e224-11e4-8c6d-c7ca21fe78d7.png)